### PR TITLE
Modernize against current scqubits (env pin + Circuit.from_yaml_string)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,8 @@ dependencies:
   - cycler
   - pathos
   - dill
-  - scqubits==2.0
+  - scqubits>=4.3
   - ipywidgets
+  - ipyvuetify
   - sympy
+  - qutip-qip

--- a/examples/demo_customcircuit.ipynb
+++ b/examples/demo_customcircuit.ipynb
@@ -78,7 +78,7 @@
    },
    "outputs": [],
    "source": [
-    "zero_pi = scq.Circuit(zp_yaml, from_file=False, ext_basis=\"discretized\")"
+    "zero_pi = scq.Circuit.from_yaml_string(zp_yaml, ext_basis=\"discretized\")"
    ]
   },
   {


### PR DESCRIPTION
Two small fixes so the examples track current scqubits.

## `environment.yml`

- Bump `scqubits==2.0` -> `scqubits>=4.3`. The pin was years out of date; anyone building the conda environment from this file got an ancient library that does not match the notebooks.
- Add `ipyvuetify` (GUI / explorer demos) and `qutip-qip` (the `demo_qutip_*` notebooks import it). Neither is pulled in transitively for conda users.

This file is not used by CI — CI installs scqubits from git and uses `workflow-requirements.info` — but it is what local users and Binder rely on.

## `demo_customcircuit.ipynb`

Replace the deprecated `scq.Circuit(zp_yaml, from_file=False, ...)` call with the named constructor `scq.Circuit.from_yaml_string(zp_yaml, ...)`. `from_file` is deprecated as of scqubits 4.3.2 (currently on scqubits `main`); `--nbval-lax` does not fail on the resulting `DeprecationWarning`, so it would otherwise go unnoticed. Source line only — execution count and cached outputs are unchanged.

## Test plan

- [ ] CI (`pytest --nbval-lax` against scqubits `main`) passes.